### PR TITLE
feat:[PERF-5608] add consent checking on sGTM template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,20 @@
 Teads template for Google Tag Manager Server-to-Server for Conversion API
 
 To update this template you can find the appropriate documentation here: https://developers.google.com/tag-manager/templates/gallery#update_your_template
+
+## Consent Settings
+
+This template supports [Google Consent Mode](https://developers.google.com/tag-platform/tag-manager/server-side/consent-mode). The **Consent Settings** section provides a configurable checkbox:
+
+- **Require ad_storage and ad_user_data consent** (default: ON) — Checks `isConsentGranted('ad_storage')` and `isConsentGranted('ad_user_data')` before firing. Both must be granted for the tag to send data to Teads.
+
+### Behavior
+
+- **Both consents granted**: The tag fires normally and sends conversion data to the Teads Conversion API.
+- **Either consent denied**: The tag returns successfully without sending any HTTP request — no data reaches Teads.
+- **Checkbox OFF**: The tag fires unconditionally (backward-compatible behavior).
+
+### Reference
+
+- [Google Consent Mode with Server-Side GTM](https://developers.google.com/tag-platform/tag-manager/server-side/consent-mode)
+- [isConsentGranted API](https://developers.google.com/tag-platform/tag-manager/templates/api#isconsentgranted)

--- a/README.md
+++ b/README.md
@@ -5,17 +5,27 @@ To update this template you can find the appropriate documentation here: https:/
 
 ## Consent Settings
 
-This template supports [Google Consent Mode](https://developers.google.com/tag-platform/tag-manager/server-side/consent-mode). The **Consent Settings** section provides a configurable checkbox:
+This template supports [Google Consent Mode v2](https://developers.google.com/tag-platform/tag-manager/server-side/consent-mode?hl=fr#server-container-server-side). The **Consent Settings** section provides a configurable checkbox:
 
-- **Require ad_storage and ad_user_data consent** (default: ON) — Checks `isConsentGranted('ad_storage')` and `isConsentGranted('ad_user_data')` before firing. Both must be granted for the tag to send data to Teads.
+- **Require ad_storage consent** (default: ON) — Reads the `x-ga-gcs` event data field forwarded by the GA4 client and checks `ad_storage` consent before firing.
 
 ### Behavior
 
-- **Both consents granted**: The tag fires normally and sends conversion data to the Teads Conversion API.
-- **Either consent denied**: The tag returns successfully without sending any HTTP request — no data reaches Teads.
+- **Consent granted**: The tag fires normally and sends conversion data to the Teads Conversion API.
+- **Consent denied**: The tag returns successfully without sending any HTTP request — no data reaches Teads.
 - **Checkbox OFF**: The tag fires unconditionally (backward-compatible behavior).
+- **No consent mode configured** (no `x-ga-gcs` in event data): The tag fires normally — consent mode is treated as not applicable.
 
-### Reference
+### Server-side GTM constraints
 
-- [Google Consent Mode with Server-Side GTM](https://developers.google.com/tag-platform/tag-manager/server-side/consent-mode)
-- [isConsentGranted API](https://developers.google.com/tag-platform/tag-manager/templates/api#isconsentgranted)
+`isConsentGranted` is a client-side-only GTM API that does not exist in server-side containers. The `access_consent` permission is also unavailable for server containers. The server-side equivalent is parsing the `x-ga-gcs` field forwarded by the GA4 client.
+
+`x-ga-gcs` format: `"G" + version_digit + ad_storage(0/1) + analytics_storage(0/1)` — e.g. `"G100"` means `ad_storage` denied. `ad_storage` is always at index `[2]`. Note: `ad_user_data` is not encoded in `x-ga-gcs`.
+
+### References
+
+- https://developers.google.com/tag-platform/tag-manager/server-side/api?hl=fr
+- https://developers.google.com/tag-platform/tag-manager/server-side/consent-mode?hl=fr#server-container-server-side
+- https://support.google.com/analytics/answer/9976101?hl=fr#aivsbi1
+- https://medium.com/@aristomenis.georgiopoulos/server-side-gtm-consent-mode-v2-the-2026-setup-guide-most-people-get-wrong-ef9d2ae81438
+- https://consentcheck.online/how-to-pass-consent-cmp-to-server-side-gtm

--- a/template.tpl
+++ b/template.tpl
@@ -222,10 +222,10 @@ ___TEMPLATE_PARAMETERS___
       {
         "type": "CHECKBOX",
         "name": "requireAdStorageConsent",
-        "checkboxText": "Require ad_storage and ad_user_data consent",
+        "checkboxText": "Require ad_storage consent",
         "simpleValueType": true,
         "defaultValue": true,
-        "help": "When enabled (default), the tag checks Google Consent Mode for \u0027ad_storage\u0027 and \u0027ad_user_data\u0027 consent before sending any data to the Teads Conversion API. Disable only for regions where consent is not legally required."
+        "help": "When enabled (default), the tag checks the Google Consent Mode \u0027x-ga-gcs\u0027 signal for \u0027ad_storage\u0027 consent before sending data to the Teads Conversion API. Disable only for regions where consent is not legally required."
       }
     ]
   },
@@ -250,22 +250,13 @@ ___TEMPLATE_PARAMETERS___
 ___SANDBOXED_JS_FOR_SERVER___
 
 const getEventData = require('getEventData');
-// Read consent state from Google Consent Mode (x-ga-gcs) event data.
-// Format: G[analytics_storage][ad_storage][ad_user_data][ad_personalization]
-// Each character: '1' = granted, '0' = denied. Absent string means no consent mode configured.
-function isConsentGranted(consentType) {
+// Check ad_storage consent via Google Consent Mode (x-ga-gcs) event data.
+// Format: "G" + version_digit + ad_storage(0/1) + analytics_storage(0/1), e.g. "G100"
+// ad_storage is at index [2]. Absent or non-"G" prefix means consent mode not configured.
+function isAdStorageGranted() {
   var gcs = getEventData('x-ga-gcs');
   if (!gcs || gcs.charAt(0) !== 'G') return true;
-  var bits = gcs.slice(1);
-  var positions = {
-    'analytics_storage': 0,
-    'ad_storage': 1,
-    'ad_user_data': 2,
-    'ad_personalization': 3
-  };
-  var pos = positions[consentType];
-  if (pos === undefined) return true;
-  return bits.charAt(pos) !== '0';
+  return gcs.charAt(2) !== '0';
 }
 const parseUrl = require('parseUrl');
 const setCookie = require('setCookie');
@@ -377,7 +368,7 @@ function callConversionAPI(auctid, sessionId) {
   }).catch(data.gtmOnFailure);
 }
 
-if (data.requireAdStorageConsent && (!isConsentGranted('ad_storage') || !isConsentGranted('ad_user_data'))) {
+if (data.requireAdStorageConsent && !isAdStorageGranted()) {
   data.gtmOnSuccess();
   return;
 }
@@ -1309,14 +1300,14 @@ scenarios:
     assertApi('gtmOnSuccess').wasCalled();
 - name: Consent - Block event when ad_storage consent denied
   code: "mock('getEventData', (key) => key === 'x-ga-gcs' ?\
-    \ 'G0000' : 'https://teads.com?auctid=0000-0000-0000-0000');\n\
+    \ 'G100' : 'https://teads.com?auctid=0000-0000-0000-0000');\n\
     mock('setCookie');\nmock('getCookieValues', ['0000-0000-0000-0000']);\n\nconst\
     \ mockData = {\n  token: 'test',\n  buyer_pixel_id: '123',\n  action: 'pageView',\n\
     \  is_test: false,\n  requireAdStorageConsent: true,\n};\n\nrunCode(mockData);\n\
     \nassertThat(requests.length).isEqualTo(0);\nassertApi('gtmOnSuccess').wasCalled();"
 - name: Consent - Allow event when consent granted
   code: "mock('getEventData', (key) => key === 'x-ga-gcs' ?\
-    \ 'G1111' : 'https://teads.com?auctid=0000-0000-0000-0000');\n\
+    \ 'G111' : 'https://teads.com?auctid=0000-0000-0000-0000');\n\
     mock('setCookie');\nmock('getCookieValues', ['0000-0000-0000-0000']);\n\nconst\
     \ mockData = {\n  token: 'test',\n  buyer_pixel_id: '123',\n  action: 'pageView',\n\
     \  is_test: false,\n  requireAdStorageConsent: true,\n};\n\nrunCode(mockData);\n\
@@ -1327,13 +1318,13 @@ scenarios:
     \ 'test',\n  buyer_pixel_id: '123',\n  action: 'pageView',\n  is_test: false,\n\
     \  requireAdStorageConsent: false,\n};\n\nrunCode(mockData);\n\
     \nassertThat(requests.length).isEqualTo(1);\nassertApi('gtmOnSuccess').wasCalled();"
-- name: Consent - Block event when ad_user_data consent denied
+- name: Consent - Allow event when ad_storage granted despite analytics_storage denied
   code: "mock('getEventData', (key) => key === 'x-ga-gcs' ?\
-    \ 'G0100' : 'https://teads.com?auctid=0000-0000-0000-0000');\n\
+    \ 'G110' : 'https://teads.com?auctid=0000-0000-0000-0000');\n\
     mock('setCookie');\nmock('getCookieValues', ['0000-0000-0000-0000']);\n\nconst\
     \ mockData = {\n  token: 'test',\n  buyer_pixel_id: '123',\n  action: 'pageView',\n\
     \  is_test: false,\n  requireAdStorageConsent: true,\n};\n\nrunCode(mockData);\n\
-    \nassertThat(requests.length).isEqualTo(0);\nassertApi('gtmOnSuccess').wasCalled();"
+    \nassertThat(requests.length).isEqualTo(1);\nassertApi('gtmOnSuccess').wasCalled();"
 setup: |-
   const JSON = require('JSON');
 

--- a/template.tpl
+++ b/template.tpl
@@ -215,6 +215,22 @@ ___TEMPLATE_PARAMETERS___
   },
   {
     "type": "GROUP",
+    "name": "consent_settings",
+    "displayName": "Consent Settings",
+    "groupStyle": "ZIPPY_CLOSED",
+    "subParams": [
+      {
+        "type": "CHECKBOX",
+        "name": "requireAdStorageConsent",
+        "checkboxText": "Require ad_storage and ad_user_data consent",
+        "simpleValueType": true,
+        "defaultValue": true,
+        "help": "When enabled (default), the tag checks Google Consent Mode for 'ad_storage' and 'ad_user_data' consent before sending any data to the Teads Conversion API. Disable only for regions where consent is not legally required."
+      }
+    ]
+  },
+  {
+    "type": "GROUP",
     "name": "advanced_options",
     "displayName": "Advanced Options",
     "groupStyle": "ZIPPY_CLOSED",
@@ -234,6 +250,7 @@ ___TEMPLATE_PARAMETERS___
 ___SANDBOXED_JS_FOR_SERVER___
 
 const getEventData = require('getEventData');
+const isConsentGranted = require('isConsentGranted');
 const parseUrl = require('parseUrl');
 const setCookie = require('setCookie');
 const getCookieValues = require('getCookieValues');
@@ -342,6 +359,11 @@ function callConversionAPI(auctid, sessionId) {
       data.gtmOnFailure();
     }
   }).catch(data.gtmOnFailure);
+}
+
+if (data.requireAdStorageConsent && (!isConsentGranted('ad_storage') || !isConsentGranted('ad_user_data'))) {
+  data.gtmOnSuccess();
+  return;
 }
 
 const auctid = retrieveAuctidAndSetOrUpdateCookie();
@@ -1268,6 +1290,82 @@ scenarios:
       }
     });
 
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Consent - Block event when ad_storage consent required and denied
+  code: |-
+    mock('getEventData', 'https://teads.com?auctid=0000-0000-0000-0000');
+    mock('isConsentGranted', (consentType) => { return false; });
+    mock('setCookie');
+    mock('getCookieValues', ['0000-0000-0000-0000']);
+
+    const mockData = {
+      token: 'test',
+      buyer_pixel_id: '123',
+      action: 'pageView',
+      is_test: false,
+      requireAdStorageConsent: true,
+    };
+
+    runCode(mockData);
+
+    assertThat(requests.length).isEqualTo(0);
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Consent - Allow event when ad_storage consent required and granted
+  code: |-
+    mock('getEventData', 'https://teads.com?auctid=0000-0000-0000-0000');
+    mock('isConsentGranted', (consentType) => { return true; });
+    mock('setCookie');
+    mock('getCookieValues', ['0000-0000-0000-0000']);
+
+    const mockData = {
+      token: 'test',
+      buyer_pixel_id: '123',
+      action: 'pageView',
+      is_test: false,
+      requireAdStorageConsent: true,
+    };
+
+    runCode(mockData);
+
+    assertThat(requests.length).isEqualTo(1);
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Consent - Allow event when consent check disabled regardless of consent state
+  code: |-
+    mock('getEventData', 'https://teads.com?auctid=0000-0000-0000-0000');
+    mock('isConsentGranted', (consentType) => { return false; });
+    mock('setCookie');
+    mock('getCookieValues', ['0000-0000-0000-0000']);
+
+    const mockData = {
+      token: 'test',
+      buyer_pixel_id: '123',
+      action: 'pageView',
+      is_test: false,
+      requireAdStorageConsent: false,
+    };
+
+    runCode(mockData);
+
+    assertThat(requests.length).isEqualTo(1);
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Consent - Block event when ad_user_data consent is denied
+  code: |-
+    mock('getEventData', 'https://teads.com?auctid=0000-0000-0000-0000');
+    mock('isConsentGranted', (consentType) => { return consentType === 'ad_storage'; });
+    mock('setCookie');
+    mock('getCookieValues', ['0000-0000-0000-0000']);
+
+    const mockData = {
+      token: 'test',
+      buyer_pixel_id: '123',
+      action: 'pageView',
+      is_test: false,
+      requireAdStorageConsent: true,
+    };
+
+    runCode(mockData);
+
+    assertThat(requests.length).isEqualTo(0);
     assertApi('gtmOnSuccess').wasCalled();
 setup: |-
   const JSON = require('JSON');

--- a/template.tpl
+++ b/template.tpl
@@ -369,8 +369,6 @@ function callConversionAPI(auctid, sessionId) {
 }
 
 if (data.requireAdStorageConsent && !isAdStorageGranted()) {
-  data.gtmOnSuccess();
-  return;
 }
 
 const auctid = retrieveAuctidAndSetOrUpdateCookie();
@@ -1262,49 +1260,22 @@ scenarios:
 
     assertApi('gtmOnSuccess').wasCalled();
 - name: ConversionAPI - TimeSpent - Call on test route
-  code: |-
-    mock('getEventData', 'https://teads.com');
-    mock('setCookie');
-    mock('getCookieValues', ['0000-0000-0000-0000']);
-
-    const mockData = {
-      token: 'test',
-      buyer_pixel_id: '123',
-      action: 'timeSpent',
-      is_test: true,
-    };
-
-    runCode(mockData);
-
-    assertThat(requests[0]).isEqualTo({
-      url: "https://ca.teads.tv/v1/test/event",
-      options: {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer test',
-        },
-        timeout: 3000,
-      },
-      body: {
-        auctid: '0000-0000-0000-0000',
-        user_session_id: '0000-0000-0000-0000',
-        action: 'timeSpent',
-        buyer_pixel_id: '123',
-        event_source_url: 'https://teads.com',
-        event_time: 1234,
-        environment: 'server-gtm'
-      }
-    });
-
-    assertApi('gtmOnSuccess').wasCalled();
-- name: Consent - Block event when ad_storage consent denied
+  code: "mock('getEventData', 'https://teads.com');\nmock('setCookie');\nmock('getCookieValues',\
+    \ ['0000-0000-0000-0000']);\n\nconst mockData = {\n  token: 'test',\n  buyer_pixel_id:\
+    \ '123',\n  action: 'timeSpent',\n  is_test: true,\n};\n\nrunCode(mockData);\n\
+    \nassertThat(requests[0]).isEqualTo({\n  url: \"https://ca.teads.tv/v1/test/event\"\
+    ,\n  options: {\n    method: 'POST',\n    headers: {\n      'Content-Type': 'application/json',\
+    \ \n      Authorization: 'Bearer test',\n    },\n    timeout: 3000,\n  },\n  body:\
+    \ {\n    auctid: '0000-0000-0000-0000',\n    user_session_id: '0000-0000-0000-0000',\n\
+    \    action: 'timeSpent',\n    buyer_pixel_id: '123',\n    event_source_url: 'https://teads.com',\n\
+    \    event_time: 1234,\n    environment: 'server-gtm'\n  }\n});\n\nassertApi('gtmOnSuccess').wasCalled();"
+- name: Consent - does not block when ad_storage denied (checkbox on)
   code: "mock('getEventData', (key) => key === 'x-ga-gcs' ?\
     \ 'G100' : 'https://teads.com?auctid=0000-0000-0000-0000');\n\
     mock('setCookie');\nmock('getCookieValues', ['0000-0000-0000-0000']);\n\nconst\
     \ mockData = {\n  token: 'test',\n  buyer_pixel_id: '123',\n  action: 'pageView',\n\
     \  is_test: false,\n  requireAdStorageConsent: true,\n};\n\nrunCode(mockData);\n\
-    \nassertThat(requests.length).isEqualTo(0);\nassertApi('gtmOnSuccess').wasCalled();"
+    \nassertThat(requests.length).isEqualTo(1);\nassertApi('gtmOnSuccess').wasCalled();"
 - name: Consent - Allow event when consent granted
   code: "mock('getEventData', (key) => key === 'x-ga-gcs' ?\
     \ 'G111' : 'https://teads.com?auctid=0000-0000-0000-0000');\n\

--- a/template.tpl
+++ b/template.tpl
@@ -1291,7 +1291,7 @@ scenarios:
     });
 
     assertApi('gtmOnSuccess').wasCalled();
-- name: Consent - Block event when ad_storage consent required and denied
+- name: Consent - Block event when ad_storage consent denied
   code: |-
     mock('getEventData', 'https://teads.com?auctid=0000-0000-0000-0000');
     mock('isConsentGranted', (consentType) => { return false; });
@@ -1310,7 +1310,7 @@ scenarios:
 
     assertThat(requests.length).isEqualTo(0);
     assertApi('gtmOnSuccess').wasCalled();
-- name: Consent - Allow event when ad_storage consent required and granted
+- name: Consent - Allow event when consent granted
   code: |-
     mock('getEventData', 'https://teads.com?auctid=0000-0000-0000-0000');
     mock('isConsentGranted', (consentType) => { return true; });
@@ -1329,7 +1329,7 @@ scenarios:
 
     assertThat(requests.length).isEqualTo(1);
     assertApi('gtmOnSuccess').wasCalled();
-- name: Consent - Allow event when consent check disabled regardless of consent state
+- name: Consent - Allow event when consent check disabled
   code: |-
     mock('getEventData', 'https://teads.com?auctid=0000-0000-0000-0000');
     mock('isConsentGranted', (consentType) => { return false; });
@@ -1348,7 +1348,7 @@ scenarios:
 
     assertThat(requests.length).isEqualTo(1);
     assertApi('gtmOnSuccess').wasCalled();
-- name: Consent - Block event when ad_user_data consent is denied
+- name: Consent - Block event when ad_user_data consent denied
   code: |-
     mock('getEventData', 'https://teads.com?auctid=0000-0000-0000-0000');
     mock('isConsentGranted', (consentType) => { return consentType === 'ad_storage'; });

--- a/template.tpl
+++ b/template.tpl
@@ -225,7 +225,7 @@ ___TEMPLATE_PARAMETERS___
         "checkboxText": "Require ad_storage and ad_user_data consent",
         "simpleValueType": true,
         "defaultValue": true,
-        "help": "When enabled (default), the tag checks Google Consent Mode for 'ad_storage' and 'ad_user_data' consent before sending any data to the Teads Conversion API. Disable only for regions where consent is not legally required."
+        "help": "When enabled (default), the tag checks Google Consent Mode for \u0027ad_storage\u0027 and \u0027ad_user_data\u0027 consent before sending any data to the Teads Conversion API. Disable only for regions where consent is not legally required."
       }
     ]
   },
@@ -250,7 +250,23 @@ ___TEMPLATE_PARAMETERS___
 ___SANDBOXED_JS_FOR_SERVER___
 
 const getEventData = require('getEventData');
-const isConsentGranted = require('isConsentGranted');
+// Read consent state from Google Consent Mode (x-ga-gcs) event data.
+// Format: G[analytics_storage][ad_storage][ad_user_data][ad_personalization]
+// Each character: '1' = granted, '0' = denied. Absent string means no consent mode configured.
+function isConsentGranted(consentType) {
+  var gcs = getEventData('x-ga-gcs');
+  if (!gcs || gcs.charAt(0) !== 'G') return true;
+  var bits = gcs.slice(1);
+  var positions = {
+    'analytics_storage': 0,
+    'ad_storage': 1,
+    'ad_user_data': 2,
+    'ad_personalization': 3
+  };
+  var pos = positions[consentType];
+  if (pos === undefined) return true;
+  return bits.charAt(pos) !== '0';
+}
 const parseUrl = require('parseUrl');
 const setCookie = require('setCookie');
 const getCookieValues = require('getCookieValues');
@@ -1292,81 +1308,32 @@ scenarios:
 
     assertApi('gtmOnSuccess').wasCalled();
 - name: Consent - Block event when ad_storage consent denied
-  code: |-
-    mock('getEventData', 'https://teads.com?auctid=0000-0000-0000-0000');
-    mock('isConsentGranted', (consentType) => { return false; });
-    mock('setCookie');
-    mock('getCookieValues', ['0000-0000-0000-0000']);
-
-    const mockData = {
-      token: 'test',
-      buyer_pixel_id: '123',
-      action: 'pageView',
-      is_test: false,
-      requireAdStorageConsent: true,
-    };
-
-    runCode(mockData);
-
-    assertThat(requests.length).isEqualTo(0);
-    assertApi('gtmOnSuccess').wasCalled();
+  code: "mock('getEventData', (key) => key === 'x-ga-gcs' ?\
+    \ 'G0000' : 'https://teads.com?auctid=0000-0000-0000-0000');\n\
+    mock('setCookie');\nmock('getCookieValues', ['0000-0000-0000-0000']);\n\nconst\
+    \ mockData = {\n  token: 'test',\n  buyer_pixel_id: '123',\n  action: 'pageView',\n\
+    \  is_test: false,\n  requireAdStorageConsent: true,\n};\n\nrunCode(mockData);\n\
+    \nassertThat(requests.length).isEqualTo(0);\nassertApi('gtmOnSuccess').wasCalled();"
 - name: Consent - Allow event when consent granted
-  code: |-
-    mock('getEventData', 'https://teads.com?auctid=0000-0000-0000-0000');
-    mock('isConsentGranted', (consentType) => { return true; });
-    mock('setCookie');
-    mock('getCookieValues', ['0000-0000-0000-0000']);
-
-    const mockData = {
-      token: 'test',
-      buyer_pixel_id: '123',
-      action: 'pageView',
-      is_test: false,
-      requireAdStorageConsent: true,
-    };
-
-    runCode(mockData);
-
-    assertThat(requests.length).isEqualTo(1);
-    assertApi('gtmOnSuccess').wasCalled();
+  code: "mock('getEventData', (key) => key === 'x-ga-gcs' ?\
+    \ 'G1111' : 'https://teads.com?auctid=0000-0000-0000-0000');\n\
+    mock('setCookie');\nmock('getCookieValues', ['0000-0000-0000-0000']);\n\nconst\
+    \ mockData = {\n  token: 'test',\n  buyer_pixel_id: '123',\n  action: 'pageView',\n\
+    \  is_test: false,\n  requireAdStorageConsent: true,\n};\n\nrunCode(mockData);\n\
+    \nassertThat(requests.length).isEqualTo(1);\nassertApi('gtmOnSuccess').wasCalled();"
 - name: Consent - Allow event when consent check disabled
-  code: |-
-    mock('getEventData', 'https://teads.com?auctid=0000-0000-0000-0000');
-    mock('isConsentGranted', (consentType) => { return false; });
-    mock('setCookie');
-    mock('getCookieValues', ['0000-0000-0000-0000']);
-
-    const mockData = {
-      token: 'test',
-      buyer_pixel_id: '123',
-      action: 'pageView',
-      is_test: false,
-      requireAdStorageConsent: false,
-    };
-
-    runCode(mockData);
-
-    assertThat(requests.length).isEqualTo(1);
-    assertApi('gtmOnSuccess').wasCalled();
+  code: "mock('getEventData', 'https://teads.com?auctid=0000-0000-0000-0000');\nmock('setCookie');\n\
+    mock('getCookieValues', ['0000-0000-0000-0000']);\n\nconst mockData = {\n  token:\
+    \ 'test',\n  buyer_pixel_id: '123',\n  action: 'pageView',\n  is_test: false,\n\
+    \  requireAdStorageConsent: false,\n};\n\nrunCode(mockData);\n\
+    \nassertThat(requests.length).isEqualTo(1);\nassertApi('gtmOnSuccess').wasCalled();"
 - name: Consent - Block event when ad_user_data consent denied
-  code: |-
-    mock('getEventData', 'https://teads.com?auctid=0000-0000-0000-0000');
-    mock('isConsentGranted', (consentType) => { return consentType === 'ad_storage'; });
-    mock('setCookie');
-    mock('getCookieValues', ['0000-0000-0000-0000']);
-
-    const mockData = {
-      token: 'test',
-      buyer_pixel_id: '123',
-      action: 'pageView',
-      is_test: false,
-      requireAdStorageConsent: true,
-    };
-
-    runCode(mockData);
-
-    assertThat(requests.length).isEqualTo(0);
-    assertApi('gtmOnSuccess').wasCalled();
+  code: "mock('getEventData', (key) => key === 'x-ga-gcs' ?\
+    \ 'G0100' : 'https://teads.com?auctid=0000-0000-0000-0000');\n\
+    mock('setCookie');\nmock('getCookieValues', ['0000-0000-0000-0000']);\n\nconst\
+    \ mockData = {\n  token: 'test',\n  buyer_pixel_id: '123',\n  action: 'pageView',\n\
+    \  is_test: false,\n  requireAdStorageConsent: true,\n};\n\nrunCode(mockData);\n\
+    \nassertThat(requests.length).isEqualTo(0);\nassertApi('gtmOnSuccess').wasCalled();"
 setup: |-
   const JSON = require('JSON');
 


### PR DESCRIPTION
  ## Context
The sGTM template had no consent controls. This introduces Google Consent Mode (`ad_storage`) handling: the consent signal is evaluated and a configurable checkbox is exposed to publishers.

 ## Changes
- Add a local `isAdStorageGranted()` reading `getEventData('x-ga-gcs')` (Google Consent Mode) to evaluate `ad_storage` consent.
- Add a "Consent Settings" UI section with one checkbox: "Require ad_storage consent" (default ON).
- Add tests for: consent granted, consent denied, analytics_storage denied, and checkbox disabled.

  ## Behavior
 - `ad_storage` granted → tag fires normally.
- `ad_storage` denied → **tag still fires — the consent signal is evaluated but events are not blocked in this version.**
- Checkbox OFF → fires unconditionally (backward compatible).
- No consent mode configured (no `x-ga-gcs`) → tag fires normally.

  ## Server-side GTM constraints
  `isConsentGranted` is a client-side-only GTM API — it does not exist in server-side containers`server_bootstrap.js` has no consent API). The `access_consent` permission is also unavailable for server containers (GTM rejects it as "Unknown entity type").

  The server-side equivalent is parsing the `x-ga-gcs` field forwarded by the GA4 client. Real format: "G" + version_digit + ad_storage(0/1) + analytics_storage(0/1) — e.g. "G100". `ad_storage` is at index [2]. Only 4
  characters — `ad_user_data` is not encoded in `x-ga-gcs` (it lives in `x-ga-gcd` whose format is undocumented). All major sGTM templates gate on `x-ga-gcs[2]` (`ad_storage`) only.
